### PR TITLE
Support building for Python 3

### DIFF
--- a/CMake/FindNumPy.cmake
+++ b/CMake/FindNumPy.cmake
@@ -16,7 +16,7 @@ FIND_PACKAGE(PythonInterp REQUIRED)
 
 # Look for the include path
 # WARNING: The variable PYTHON_EXECUTABLE is defined by the script FindPythonInterp.cmake
-EXECUTE_PROCESS(COMMAND "${PYTHON_EXECUTABLE}" -c "import numpy; print numpy.get_include(); print numpy.version.version"
+EXECUTE_PROCESS(COMMAND "${PYTHON_EXECUTABLE}" -c "from __future__ import print_function; import numpy; print(numpy.get_include()); print(numpy.version.version)"
                  OUTPUT_VARIABLE NUMPY_OUTPUT
                  ERROR_VARIABLE NUMPY_ERROR)
                  


### PR DESCRIPTION
The library just works for Python 3, but the compilation has a small problem with `print` no longer being a keyword but a function. This makes it so that CMAKE thinks `numpy` is not installed.

So this PR changes the CMAKE instructions needed to find `numpy` so that they work on both Python 3 and Python 2.

Note that Python 2.7 will be end-of-life in about seven months, so getting Python 3 support in is pretty important. Luckily it seems to be very easy.