### PR TITLE
Removed dynamic exception specifications to comply with C++17.

### DIFF
--- a/Utilities/Open3DMotion/src/Open3DMotion/Biomechanics/Trial/TSFactory.h
+++ b/Utilities/Open3DMotion/src/Open3DMotion/Biomechanics/Trial/TSFactory.h
@@ -51,7 +51,7 @@ namespace Open3DMotion
 	class TSScalarConstIter : public BinConstIter1<double>
 	{
 	public:
-		TSScalarConstIter(const TimeSequence& ts) throw(NoSuchFieldException)  :
+		TSScalarConstIter(const TimeSequence& ts) :
 				BinConstIter1<double>(ts, TSFactoryValue::fieldname_value, 1)
 		{
 		}
@@ -64,7 +64,7 @@ namespace Open3DMotion
 	class TSScalarIter : public BinIter1<double>
 	{
 	public:
-		TSScalarIter(TimeSequence& ts) throw(NoSuchFieldException)  :
+		TSScalarIter(TimeSequence& ts) :
 				BinIter1<double>(ts, TSFactoryValue::fieldname_value, 1)
 		{
 		}
@@ -77,7 +77,7 @@ namespace Open3DMotion
 	class TSVector3ConstIter : public BinConstIter1<double>
 	{
 	public:
-			TSVector3ConstIter(const TimeSequence& ts) throw(NoSuchFieldException) :
+			TSVector3ConstIter(const TimeSequence& ts) :
 				BinConstIter1<double>(ts, TSFactoryValue::fieldname_value, 3)
 		{
 		}
@@ -90,7 +90,7 @@ namespace Open3DMotion
 	class TSVector3Iter : public BinIter1<double>
 	{
 	public:
-		TSVector3Iter(TimeSequence& ts) throw(NoSuchFieldException)  :
+		TSVector3Iter(TimeSequence& ts) :
 				BinIter1<double>(ts, TSFactoryValue::fieldname_value, 3)
 		{
 		}
@@ -103,7 +103,7 @@ namespace Open3DMotion
 	class TSOccVector3ConstIter : public BinConstIter2<double, UInt8>
 	{
 	public:
-			TSOccVector3ConstIter(const TimeSequence& ts) throw(NoSuchFieldException) :
+			TSOccVector3ConstIter(const TimeSequence& ts) :
 				BinConstIter2<double, UInt8>(ts, TSFactoryValue::fieldname_value, 3, TSFactoryOccValue::fieldname_occluded, 1)
 		{
 		}
@@ -119,7 +119,7 @@ namespace Open3DMotion
 	class TSOccVector3Iter : public BinIter2<double, UInt8>
 	{
 	public:
-		TSOccVector3Iter(TimeSequence& ts) throw(NoSuchFieldException)  :
+		TSOccVector3Iter(TimeSequence& ts) :
 			BinIter2<double, UInt8>(ts, TSFactoryValue::fieldname_value, 3, TSFactoryOccValue::fieldname_occluded, 1)
 		{
 		}
@@ -135,7 +135,7 @@ namespace Open3DMotion
 	class TSOccConstIter : public BinConstIter1<UInt8>
 	{
 	public:
-		TSOccConstIter(const TimeSequence& ts) throw(NoSuchFieldException)  :
+		TSOccConstIter(const TimeSequence& ts) :
 				BinConstIter1<UInt8>(ts, TSFactoryOccValue::fieldname_occluded, 1)
 		{
 		}
@@ -148,7 +148,7 @@ namespace Open3DMotion
 	class TSOccIter : public BinIter1<UInt8>
 	{
 	public:
-		TSOccIter(TimeSequence& ts) throw(NoSuchFieldException)  :
+		TSOccIter(TimeSequence& ts) :
 				BinIter1<UInt8>(ts, TSFactoryOccValue::fieldname_occluded, 1)
 		{
 		}
@@ -161,7 +161,7 @@ namespace Open3DMotion
 	class TSOccMatrix3x3ConstIter : public Open3DMotion::BinConstIter2<double, Open3DMotion::UInt8>
 	{
 	public:
-			TSOccMatrix3x3ConstIter(const Open3DMotion::TimeSequence& ts) throw(Open3DMotion::NoSuchFieldException) :
+			TSOccMatrix3x3ConstIter(const Open3DMotion::TimeSequence& ts) :
 				BinConstIter2<double, Open3DMotion::UInt8>(ts, Open3DMotion::TSFactoryValue::fieldname_value, 9, Open3DMotion::TSFactoryOccValue::fieldname_occluded, 1)
 		{
 		}
@@ -177,7 +177,7 @@ namespace Open3DMotion
 	class TSOccMatrix3x3Iter : public Open3DMotion::BinIter2<double, Open3DMotion::UInt8>
 	{
 	public:
-			TSOccMatrix3x3Iter(Open3DMotion::TimeSequence& ts) throw(Open3DMotion::NoSuchFieldException) :
+			TSOccMatrix3x3Iter(Open3DMotion::TimeSequence& ts) :
 				BinIter2<double, Open3DMotion::UInt8>(ts, Open3DMotion::TSFactoryValue::fieldname_value, 9, Open3DMotion::TSFactoryOccValue::fieldname_occluded, 1)
 		{
 		}

--- a/Utilities/Open3DMotion/src/Open3DMotion/Maths/Matrix3x3.h
+++ b/Utilities/Open3DMotion/src/Open3DMotion/Maths/Matrix3x3.h
@@ -81,7 +81,7 @@ namespace Open3DMotion
     }
 
     // retrieve element in row i, column j
-    double& operator() (int i, int j) throw(MathsException)
+    double& operator() (int i, int j)
     {
       CODAMOTION_MATHS_VERIFY(i >= 0);
       CODAMOTION_MATHS_VERIFY(j >= 0);
@@ -91,7 +91,7 @@ namespace Open3DMotion
     }
 
     // retrieve element in row i, column j (const)
-    const double& operator() (int i, int j) const throw(MathsException)
+    const double& operator() (int i, int j) const
     {
       CODAMOTION_MATHS_VERIFY(i >= 0);
       CODAMOTION_MATHS_VERIFY(j >= 0);

--- a/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/Formats/MDF/FileFormatMDF.cpp
+++ b/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/Formats/MDF/FileFormatMDF.cpp
@@ -219,7 +219,7 @@ namespace Open3DMotion
 	}
 
 	// check id and number type
-  bool FileFormatMDF::Probe(const MotionFileHandler& /*context*/, TreeValue*& readoptions, std::istream& is) const throw(MotionFileException)
+  bool FileFormatMDF::Probe(const MotionFileHandler& /*context*/, TreeValue*& readoptions, std::istream& is) const
 	{
 		FileFormatOptionsMDF mdf_options;
 
@@ -254,7 +254,7 @@ namespace Open3DMotion
 	}
 
   // Read MDF
-  TreeValue* FileFormatMDF::Read(const MotionFileHandler& /*context*/, std::istream& is, const BinMemFactory& memfactory, const TreeValue* readoptions) const throw(MotionFileException) 
+  TreeValue* FileFormatMDF::Read(const MotionFileHandler& /*context*/, std::istream& is, const BinMemFactory& memfactory, const TreeValue* readoptions) const 
 	{
 		// get options
 		FileFormatOptionsMDF mdf_options;
@@ -1040,7 +1040,7 @@ namespace Open3DMotion
 	}
 
   // Write MDF
-  void FileFormatMDF::Write(const MotionFileHandler& /*context*/, const TreeValue* contents, std::ostream& os, const TreeValue* writeoptions) const throw(MotionFileException)
+  void FileFormatMDF::Write(const MotionFileHandler& /*context*/, const TreeValue* contents, std::ostream& os, const TreeValue* writeoptions) const
 	{
 		// get write options
 		FileFormatOptionsMDF mdf_options;

--- a/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/Formats/MDF/FileFormatMDF.h
+++ b/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/Formats/MDF/FileFormatMDF.h
@@ -67,13 +67,13 @@ namespace Open3DMotion
   public:
 
 		// check id and number type
-    virtual bool Probe(const MotionFileHandler& context, TreeValue*& readoptions, std::istream& is) const throw(MotionFileException);
+    virtual bool Probe(const MotionFileHandler& context, TreeValue*& readoptions, std::istream& is) const;
 
     // Read MDF
-    virtual TreeValue* Read(const MotionFileHandler& context, std::istream& is, const BinMemFactory& memfactory, const TreeValue* readoptions) const throw(MotionFileException) ;
+    virtual TreeValue* Read(const MotionFileHandler& context, std::istream& is, const BinMemFactory& memfactory, const TreeValue* readoptions) const;
 
     // Write MDF
-    virtual void Write(const MotionFileHandler& context, const TreeValue* contents, std::ostream& os, const TreeValue* writeoptions) const throw(MotionFileException);
+    virtual void Write(const MotionFileHandler& context, const TreeValue* contents, std::ostream& os, const TreeValue* writeoptions) const;
 		
 	};
 }

--- a/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/Formats/MDF/ForcePlateMDF.cpp
+++ b/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/Formats/MDF/ForcePlateMDF.cpp
@@ -79,7 +79,7 @@ namespace Open3DMotion
 	void ForcePlateMDF::ParseMDF(
 			std::map<size_t, std::vector< std::vector<UInt8> >, std::less<size_t> >& data,
 			std::map<size_t, size_t, std::less<size_t> >& /*elementsize*/,
-			size_t iplate) throw(MotionFileException)
+			size_t iplate)
   {
 		// MDF plate ID - init to zero (invalid)
 		UInt8 id(0);
@@ -308,7 +308,7 @@ namespace Open3DMotion
 		return 0.1*floor(10.0*k + 0.5);
 	}
 
-	UInt8 ForcePlateMDF::MDFPlateID() const throw(MotionFileException)
+	UInt8 ForcePlateMDF::MDFPlateID() const
   {
 		UInt8 id(0);
     const std::string& model = Model.Value();
@@ -353,7 +353,7 @@ namespace Open3DMotion
 		return id;
   }
 
-  const char* ForcePlateMDF::IDtoType(UInt8 id) throw(MotionFileException)
+  const char* ForcePlateMDF::IDtoType(UInt8 id)
   {
     switch((int)id)
     {
@@ -378,7 +378,7 @@ namespace Open3DMotion
     }
   }
 
-  const char* ForcePlateMDF::IDtoModel(UInt8 id) throw(MotionFileException)
+  const char* ForcePlateMDF::IDtoModel(UInt8 id)
   {
     switch((int)id)
     {

--- a/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/Formats/MDF/ForcePlateMDF.h
+++ b/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/Formats/MDF/ForcePlateMDF.h
@@ -49,7 +49,7 @@ namespace Open3DMotion
 		void ParseMDF(
 			std::map<size_t, std::vector< std::vector<UInt8> >, std::less<size_t> >& data,
 			std::map<size_t, size_t, std::less<size_t> >& elementsize,
-			size_t iplate) throw(MotionFileException);
+			size_t iplate);
 
 		float MDFDefaultSaveRes(size_t ichannel) const;
 
@@ -76,7 +76,7 @@ namespace Open3DMotion
 
 		size_t RuntimeChannelToMDFChannel(size_t runchannel) const;
 
-		UInt8 MDFPlateID() const throw(MotionFileException);
+		UInt8 MDFPlateID() const;
 
 		void MDFSensorConstants(Int16* w) const;
 
@@ -125,9 +125,9 @@ namespace Open3DMotion
 
 		static double RoundSensorConst(double k);
 
-		static const char* IDtoModel(UInt8 id) throw(MotionFileException);
+		static const char* IDtoModel(UInt8 id);
 
-		static const char* IDtoType(UInt8 id) throw(MotionFileException);
+		static const char* IDtoType(UInt8 id);
 	};
 }
 

--- a/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/Formats/XMove/FileFormatXMove.cpp
+++ b/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/Formats/XMove/FileFormatXMove.cpp
@@ -31,7 +31,7 @@ namespace Open3DMotion
 	{
 	}
 
-	bool FileFormatXMove::Probe(const MotionFileHandler& /*context*/, TreeValue*& readoptions, std::istream& is) const throw(MotionFileException)
+	bool FileFormatXMove::Probe(const MotionFileHandler& /*context*/, TreeValue*& readoptions, std::istream& is) const
 	{
 		// check for format
 		if (!ProbeTextString(is, "<xmove", 1024))
@@ -49,7 +49,7 @@ namespace Open3DMotion
 		return true;
 	}
 
-  TreeValue* FileFormatXMove::Read(const MotionFileHandler& /*context*/, std::istream& is, const BinMemFactory& memfactory, const TreeValue* readoptions) const throw(MotionFileException) 
+  TreeValue* FileFormatXMove::Read(const MotionFileHandler& /*context*/, std::istream& is, const BinMemFactory& memfactory, const TreeValue* readoptions) const
 	{
 		// options
 		FileFormatOptionsXMove xmove_options;
@@ -108,7 +108,7 @@ namespace Open3DMotion
 
 	}
 
-	void FileFormatXMove::Write(const MotionFileHandler& context, const TreeValue* contents, std::ostream& os, const TreeValue* writeoptions) const throw(MotionFileException)
+	void FileFormatXMove::Write(const MotionFileHandler& context, const TreeValue* contents, std::ostream& os, const TreeValue* writeoptions) const
 	{
 		// options
 		FileFormatOptionsXMove xmove_options;

--- a/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/Formats/XMove/FileFormatXMove.h
+++ b/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/Formats/XMove/FileFormatXMove.h
@@ -28,13 +28,13 @@ namespace Open3DMotion
   public:
 
 		// check id and number type
-    virtual bool Probe(const MotionFileHandler& context, TreeValue*& readoptions, std::istream& is) const throw(MotionFileException);
+    virtual bool Probe(const MotionFileHandler& context, TreeValue*& readoptions, std::istream& is) const;
 
     // Read MDF
-    virtual TreeValue* Read(const MotionFileHandler& context, std::istream& is, const BinMemFactory& memfactory, const TreeValue* readoptions) const throw(MotionFileException) ;
+    virtual TreeValue* Read(const MotionFileHandler& context, std::istream& is, const BinMemFactory& memfactory, const TreeValue* readoptions) const;
 
     // Write MDF
-    virtual void Write(const MotionFileHandler& context, const TreeValue* contents, std::ostream& os, const TreeValue* writeoptions) const throw(MotionFileException);
+    virtual void Write(const MotionFileHandler& context, const TreeValue* contents, std::ostream& os, const TreeValue* writeoptions) const;
 		
 	protected:
 		static void ConvertListFloat32To64(TreeCompound* section, const char* listname, const char* structurename, const BinMemFactory& memfactory);

--- a/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/Formats/XMove/XMLReadingMachineLegacy.cpp
+++ b/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/Formats/XMove/XMLReadingMachineLegacy.cpp
@@ -22,7 +22,7 @@ namespace Open3DMotion
 	{
 	}
 
-	TreeValue* XMLReadingMachineLegacy::ReadValue(const pugi::xml_node& xml_element) throw(XMLReadException)
+	TreeValue* XMLReadingMachineLegacy::ReadValue(const pugi::xml_node& xml_element)
 	{
 		// element to remap
 		pugi::xml_node remapped_element = xml_element;

--- a/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/Formats/XMove/XMLReadingMachineLegacy.h
+++ b/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/Formats/XMove/XMLReadingMachineLegacy.h
@@ -20,7 +20,7 @@ namespace Open3DMotion
 		XMLReadingMachineLegacy(const BinMemFactory& _memfactory);
 
 	public:
-		virtual TreeValue* ReadValue(const pugi::xml_node& element) throw(XMLReadException);
+		virtual TreeValue* ReadValue(const pugi::xml_node& element);
 
 	public:
 

--- a/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/MotionFileFormat.h
+++ b/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/MotionFileFormat.h
@@ -61,13 +61,13 @@ namespace Open3DMotion
 
     // Is the given stream one of our files?
     // Returns: true if can load the file, false otherwise
-    virtual bool Probe(const MotionFileHandler& context, TreeValue*& readoptions, std::istream& is) const throw(MotionFileException) = 0;
+    virtual bool Probe(const MotionFileHandler& context, TreeValue*& readoptions, std::istream& is) const = 0;
 
 		// Read the file into trial object (or derived trial object)
-    virtual TreeValue* Read(const MotionFileHandler& context, std::istream& is, const BinMemFactory& memfactory, const TreeValue* readoptions) const throw(MotionFileException) = 0;
+    virtual TreeValue* Read(const MotionFileHandler& context, std::istream& is, const BinMemFactory& memfactory, const TreeValue* readoptions) const = 0;
 
 		// Write the file
-    virtual void Write(const MotionFileHandler& context, const TreeValue* contents, std::ostream& os, const TreeValue* writeoptions) const throw(MotionFileException) = 0;
+    virtual void Write(const MotionFileHandler& context, const TreeValue* contents, std::ostream& os, const TreeValue* writeoptions) const = 0;
 
 	protected:
 

--- a/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/MotionFileHandler.cpp
+++ b/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/MotionFileHandler.cpp
@@ -34,7 +34,7 @@ namespace Open3DMotion
 	TreeValue* MotionFileHandler::Read(
 		const char* filename, 
 		const MotionFileFormatList& formatlist /*=MotionFileFormatListAll()*/, 
-		const BinMemFactory& memfactory /*=BinMemFactoryDefault()*/ ) throw(MotionFileException)
+		const BinMemFactory& memfactory /*=BinMemFactoryDefault()*/ )
 	{
 #ifdef _MSC_VER
 		// creating a C-style file object may work better with UTF-8
@@ -59,7 +59,7 @@ namespace Open3DMotion
 	TreeValue* MotionFileHandler::Read(
 		std::istream& is, 
 		const MotionFileFormatList& formatlist /*=MotionFileFormatListAll()*/, 
-		const BinMemFactory& memfactory /*=BinMemFactoryDefault()*/ ) throw(MotionFileException)
+		const BinMemFactory& memfactory /*=BinMemFactoryDefault()*/ )
 	{
 		// establish the format
 		TreeValue* readoptions(NULL);
@@ -105,7 +105,7 @@ namespace Open3DMotion
 		return trialobject;
 	}
 
-	void MotionFileHandler::Write(const char* filename, const TreeValue* contents, const TreeValue* writeoptions, const MotionFileFormatList& formatlist /*=MotionFileFormatListAll()*/) throw(MotionFileException)
+	void MotionFileHandler::Write(const char* filename, const TreeValue* contents, const TreeValue* writeoptions, const MotionFileFormatList& formatlist /*=MotionFileFormatListAll()*/)
 	{
 #ifdef _MSC_VER
 		// creating a C-style file object may work better with UTF-8
@@ -123,7 +123,7 @@ namespace Open3DMotion
 		os.close();
 	}
 
-	void MotionFileHandler::Write(std::ostream& os, const char* filename, const TreeValue* contents, const TreeValue* writeoptions, const MotionFileFormatList& formatlist /*=MotionFileFormatListAll()*/) throw(MotionFileException)
+	void MotionFileHandler::Write(std::ostream& os, const char* filename, const TreeValue* contents, const TreeValue* writeoptions, const MotionFileFormatList& formatlist /*=MotionFileFormatListAll()*/)
 	{
 		// ensure write options non-NULL
 		TreeCompound emptyoptions;

--- a/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/MotionFileHandler.h
+++ b/Utilities/Open3DMotion/src/Open3DMotion/MotionFile/MotionFileHandler.h
@@ -37,16 +37,16 @@ namespace Open3DMotion
 		{ return programversion; }
 
 		/** Read from file */
-		TreeValue* Read(const char* filename, const MotionFileFormatList& formatlist = MotionFileFormatListAll(), const BinMemFactory& memfactory = BinMemFactoryDefault()) throw(MotionFileException);
+		TreeValue* Read(const char* filename, const MotionFileFormatList& formatlist = MotionFileFormatListAll(), const BinMemFactory& memfactory = BinMemFactoryDefault());
 
 		/** Read from STL stream */
-		TreeValue* Read(std::istream& is, const MotionFileFormatList& formatlist = MotionFileFormatListAll(), const BinMemFactory& memfactory = BinMemFactoryDefault()) throw(MotionFileException);
+		TreeValue* Read(std::istream& is, const MotionFileFormatList& formatlist = MotionFileFormatListAll(), const BinMemFactory& memfactory = BinMemFactoryDefault());
 
 		/** Write to file */
-		void Write(const char* filename, const TreeValue* contents, const TreeValue* writeoptions, const MotionFileFormatList& formatlist = MotionFileFormatListAll()) throw(MotionFileException);
+		void Write(const char* filename, const TreeValue* contents, const TreeValue* writeoptions, const MotionFileFormatList& formatlist = MotionFileFormatListAll());
 
 		/** Write to STL stream */
-		void Write(std::ostream& os, const char* filename, const TreeValue* contents, const TreeValue* writeoptions, const MotionFileFormatList& formatlist = MotionFileFormatListAll()) throw(MotionFileException);
+		void Write(std::ostream& os, const char* filename, const TreeValue* contents, const TreeValue* writeoptions, const MotionFileFormatList& formatlist = MotionFileFormatListAll());
 
 	private:
 		std::string programname;

--- a/Utilities/Open3DMotion/src/Open3DMotion/OpenORM/IO/XML/XMLReadingMachine.cpp
+++ b/Utilities/Open3DMotion/src/Open3DMotion/OpenORM/IO/XML/XMLReadingMachine.cpp
@@ -44,7 +44,7 @@ namespace Open3DMotion
 		return xml_class->ReadValue(*this, element);
 	}
 
-	TreeValue* XMLReadingMachine::ReadValue(const pugi::xml_node& xml_element) throw(XMLReadException)
+	TreeValue* XMLReadingMachine::ReadValue(const pugi::xml_node& xml_element)
 	{
 		for (std::vector<ReadWriteXML*>::const_iterator iter_element( element.begin() ); iter_element != element.end(); iter_element++)
 		{

--- a/Utilities/Open3DMotion/src/Open3DMotion/OpenORM/IO/XML/XMLReadingMachine.h
+++ b/Utilities/Open3DMotion/src/Open3DMotion/OpenORM/IO/XML/XMLReadingMachine.h
@@ -34,7 +34,7 @@ namespace Open3DMotion
 	   */
 		virtual TreeValue* Read(const ReadWriteXML* xml_reader, const pugi::xml_node& element);
 
-		virtual TreeValue* ReadValue(const pugi::xml_node& element) throw(XMLReadException);
+		virtual TreeValue* ReadValue(const pugi::xml_node& element);
 
 		virtual void ReadTextNode(std::string& node_text, const pugi::xml_node& element);
 

--- a/Utilities/Open3DMotion/src/Open3DMotion/OpenORM/Mappings/RichBinary/BinIter.h
+++ b/Utilities/Open3DMotion/src/Open3DMotion/OpenORM/Mappings/RichBinary/BinIter.h
@@ -31,7 +31,7 @@ namespace Open3DMotion
     virtual ~BinIterBase() {};
 
 	protected:
-		template<typename DataType> static const DataType* GetFieldPointer(const RichBinary& bin, const char* fieldname, size_t dimension) throw(NoSuchFieldException)
+		template<typename DataType> static const DataType* GetFieldPointer(const RichBinary& bin, const char* fieldname, size_t dimension)
 		{
 			// get spec and relative offset - will throw exception if not found
 			const BinaryFieldSpec* spec(NULL);
@@ -160,7 +160,7 @@ namespace Open3DMotion
 	template<typename TypeA> class BinConstIter1 : public BinIterBase
 	{
 	public:
-		BinConstIter1(const RichBinary& bin, const char* fieldA, size_t dimA) throw(NoSuchFieldException) :
+		BinConstIter1(const RichBinary& bin, const char* fieldA, size_t dimA) :
 			BinIterBase(bin),
 			a( GetFieldPointer<TypeA> (bin, fieldA, dimA) )
 		{
@@ -191,7 +191,7 @@ namespace Open3DMotion
 	template<typename TypeA> class BinIter1 : public BinConstIter1<TypeA>
 	{
 	public:
-		BinIter1(RichBinary& bin, const char* fieldA, size_t dimA)  throw(NoSuchFieldException) :
+		BinIter1(RichBinary& bin, const char* fieldA, size_t dimA) :
 			BinConstIter1<TypeA>(bin, fieldA, dimA)
 		{
 		}
@@ -205,7 +205,7 @@ namespace Open3DMotion
 	template<typename TypeA, typename TypeB> class BinConstIter2 : public BinConstIter1<TypeA>
 	{
 	public:
-		BinConstIter2(const RichBinary& bin, const char* fieldA, size_t dimA, const char* fieldB, size_t dimB) throw(NoSuchFieldException) :
+		BinConstIter2(const RichBinary& bin, const char* fieldA, size_t dimA, const char* fieldB, size_t dimB) :
 				BinConstIter1<TypeA> (bin, fieldA, dimA),
         b( BinIterBase::GetFieldPointer<TypeB>(bin, fieldB, dimB) )
 		{
@@ -238,7 +238,7 @@ namespace Open3DMotion
 	template<typename TypeA, typename TypeB> class BinIter2 : public BinConstIter2<TypeA, TypeB>
 	{
 	public:
-		BinIter2(const RichBinary& bin, const char* fieldA, size_t dimA, const char* fieldB, size_t dimB) throw(NoSuchFieldException) :
+		BinIter2(const RichBinary& bin, const char* fieldA, size_t dimA, const char* fieldB, size_t dimB) :
 				 BinConstIter2<TypeA, TypeB>(bin, fieldA, dimA, fieldB, dimB)
 		{
 		}
@@ -254,7 +254,7 @@ namespace Open3DMotion
 	template<typename TypeA, typename TypeB, typename TypeC> class BinConstIter3 : public BinConstIter2<TypeA, TypeB>
 	{
 	public:
-		BinConstIter3(const RichBinary& bin, const char* fieldA, size_t dimA, const char* fieldB, size_t dimB, const char* fieldC, size_t dimC) throw(NoSuchFieldException) :
+		BinConstIter3(const RichBinary& bin, const char* fieldA, size_t dimA, const char* fieldB, size_t dimB, const char* fieldC, size_t dimC) :
 				BinConstIter2<TypeA, TypeB> (bin, fieldA, dimA, fieldB, dimB),
         c( BinIterBase::GetFieldPointer<TypeC>(bin, fieldC, dimC) )
 		{
@@ -287,7 +287,7 @@ namespace Open3DMotion
 	template<typename TypeA, typename TypeB, typename TypeC> class BinIter3 : public BinConstIter3<TypeA, TypeB, TypeC>
 	{
 	public:
-		BinIter3(const RichBinary& bin, const char* fieldA, size_t dimA, const char* fieldB, size_t dimB, const char* fieldC, size_t dimC) throw(NoSuchFieldException) :
+		BinIter3(const RichBinary& bin, const char* fieldA, size_t dimA, const char* fieldB, size_t dimB, const char* fieldC, size_t dimC) :
 				 BinConstIter3<TypeA, TypeB, TypeC>(bin, fieldA, dimA, fieldB, dimB, fieldC, dimC)
 		{
 		}

--- a/Utilities/Open3DMotion/src/Open3DMotion/OpenORM/Mappings/RichBinary/BinaryStructure.cpp
+++ b/Utilities/Open3DMotion/src/Open3DMotion/OpenORM/Mappings/RichBinary/BinaryStructure.cpp
@@ -28,7 +28,7 @@ namespace Open3DMotion
 		}
 	}
 
-	void BinaryStructure::GetFieldOffset(BinaryFieldSpec const*& spec, size_t& offset, const char* fieldname) const throw(NoSuchFieldException)
+	void BinaryStructure::GetFieldOffset(BinaryFieldSpec const*& spec, size_t& offset, const char* fieldname) const
 	{
 		size_t n = Layout.NumElements();
 		offset = 0;

--- a/Utilities/Open3DMotion/src/Open3DMotion/OpenORM/Mappings/RichBinary/BinaryStructure.h
+++ b/Utilities/Open3DMotion/src/Open3DMotion/OpenORM/Mappings/RichBinary/BinaryStructure.h
@@ -29,7 +29,7 @@ namespace Open3DMotion
 		const MapArrayCompound<BinaryFieldSpec>& GetLayout() const
 		{ return Layout; }
 
-		void GetFieldOffset(BinaryFieldSpec const*& spec, size_t& offset, const char* fieldname) const throw(NoSuchFieldException);
+		void GetFieldOffset(BinaryFieldSpec const*& spec, size_t& offset, const char* fieldname) const;
 
 		static const char LayoutElementName[];
 


### PR DESCRIPTION
Dynamic exception specifications have been removed in C++17 and it is throwing errors. It has been deprecated since C++11.

I have removed them so it complies with C++17.